### PR TITLE
rm old dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,0 @@
----
-version: 1
-update_configs:
-- package_manager: "go:modules"
-  directory: "/"
-  update_schedule: "daily"


### PR DESCRIPTION
Dependabot must use the config in .github/dependabot.yml