### PR TITLE
use BP_CPYTHON_VERSION env var as version source

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,42 @@ The buildpack will do the following:
 * At run time:
   - Does nothing
 
-## `buildpack.yml` Configurations
+## Configuration
 
-In order to specify a particular version of python you can
-provide an optional `buildpack.yml` in the root of the application directory.
+Specifying the CPython version through `buildpack.yml` configuration
+will be deprecated in CPython Buildpack v1.0.0.
+
+To migrate from using `buildpack.yml` please set the following environment
+variables at build time either directly  or through a [`project.toml`
+file](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md).
+
+### `BP_CPYTHON_VERSION`
+The `BP_CPYTHON_VERSION` variable allows you to specify the version of CPython
+that is installed. (Available versions can be found in the
+[buildpack.toml](./buildpack.toml).)
+
+#### `pack build` flag
+```shell
+pack build my-app --env BP_CPYTHON_VERSION=3.6.*
+```
+
+#### In a [`project.toml`](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
+```toml
+[build]
+  [[build.env]]
+    name = 'BP_CPYTHON_VERSION'
+    value = '3.6.*' # any valid semver constraints (e.g. 3.6.7, 3.*) are acceptable
+```
+
+#### (Deprecated) In a `buildpack.yml`:
 
 ```yaml
 cpython:
   # this allows you to specify a version constraint for the python depdendency
-  # any valid semver constaints (e.g. 3.*) are also acceptable
+  # any valid semver constraints (e.g. 3.*) are also acceptable
   version: ~3
 ```
+
 ## Integration
 
 The CPython Buildpack provides `cpython` as a dependency. Downstream

--- a/build.go
+++ b/build.go
@@ -67,7 +67,7 @@ func Build(entries EntryResolver, dependencies DependencyManager, logs scribe.Em
 		source, _ := entry.Metadata["version-source"].(string)
 		if source == "buildpack.yml" {
 			nextMajorVersion := semver.MustParse(context.BuildpackInfo.Version).IncMajor()
-			logs.Subprocess("WARNING: Setting the CPython version through buildpack.yml will be deprecated soon in CPython Buildpack v%s.", nextMajorVersion.String())
+			logs.Subprocess("WARNING: Setting the CPython version through buildpack.yml is deprecated and will be removed in %s v%s.", context.BuildpackInfo.Name, nextMajorVersion.String())
 			logs.Subprocess("Please specify the version through the $BP_CPYTHON_VERSION environment variable instead. See docs for more information.")
 			logs.Break()
 		}

--- a/build_test.go
+++ b/build_test.go
@@ -132,7 +132,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(entryResolver.ResolveCall.Receives.BuildpackPlanEntrySlice).To(Equal([]packit.BuildpackPlanEntry{
 			{Name: "cpython"},
 		}))
-		Expect(entryResolver.ResolveCall.Receives.InterfaceSlice).To(Equal([]interface{}{"buildpack.yml"}))
+		Expect(entryResolver.ResolveCall.Receives.InterfaceSlice).To(Equal([]interface{}{"BP_CPYTHON_VERSION", "buildpack.yml"}))
 
 		Expect(entryResolver.MergeLayerTypesCall.Receives.String).To(Equal(cpython.Cpython))
 		Expect(entryResolver.MergeLayerTypesCall.Receives.BuildpackPlanEntrySlice).To(Equal(
@@ -260,6 +260,46 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 				},
 			}))
+		})
+	})
+
+	context("when the version source of the selected entry is buildpack.yml", func() {
+		it.Before(func() {
+			entryResolver.ResolveCall.Returns.BuildpackPlanEntry = packit.BuildpackPlanEntry{
+				Name: "cpython",
+				Metadata: map[string]interface{}{
+					"version-source": "buildpack.yml",
+				},
+			}
+		})
+
+		it("logs a warning that buildpack.yml will be deprecated in the next version", func() {
+			_, err := build(packit.BuildContext{
+				BuildpackInfo: packit.BuildpackInfo{
+					Name:    "Some Buildpack",
+					Version: "1.2.3",
+				},
+				CNBPath: cnbDir,
+				Plan: packit.BuildpackPlan{
+					Entries: []packit.BuildpackPlanEntry{
+						{
+							Name: "cpython",
+						},
+					},
+				},
+				Layers: packit.Layers{Path: layersDir},
+				Stack:  "some-stack",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(buffer.String()).To(ContainSubstring("Some Buildpack 1.2.3"))
+			Expect(buffer.String()).To(ContainSubstring("Resolving CPython version"))
+			Expect(buffer.String()).To(ContainSubstring("Selected CPython version (using buildpack.yml): python-dependency-version"))
+			Expect(buffer.String()).To(ContainSubstring("WARNING: Setting the CPython version through buildpack.yml will be deprecated soon in CPython Buildpack v2.0.0."))
+			Expect(buffer.String()).To(ContainSubstring("Please specify the version through the $BP_CPYTHON_VERSION environment variable instead. See docs for more information."))
+			Expect(buffer.String()).To(ContainSubstring("Executing build process"))
+			Expect(buffer.String()).To(ContainSubstring("Installing CPython python-dependency-version"))
+			Expect(buffer.String()).To(ContainSubstring("Completed in"))
 		})
 	})
 

--- a/build_test.go
+++ b/build_test.go
@@ -295,7 +295,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(buffer.String()).To(ContainSubstring("Some Buildpack 1.2.3"))
 			Expect(buffer.String()).To(ContainSubstring("Resolving CPython version"))
 			Expect(buffer.String()).To(ContainSubstring("Selected CPython version (using buildpack.yml): python-dependency-version"))
-			Expect(buffer.String()).To(ContainSubstring("WARNING: Setting the CPython version through buildpack.yml will be deprecated soon in CPython Buildpack v2.0.0."))
+			Expect(buffer.String()).To(ContainSubstring("WARNING: Setting the CPython version through buildpack.yml is deprecated and will be removed in Some Buildpack v2.0.0."))
 			Expect(buffer.String()).To(ContainSubstring("Please specify the version through the $BP_CPYTHON_VERSION environment variable instead. See docs for more information."))
 			Expect(buffer.String()).To(ContainSubstring("Executing build process"))
 			Expect(buffer.String()).To(ContainSubstring("Installing CPython python-dependency-version"))

--- a/constants.go
+++ b/constants.go
@@ -10,4 +10,11 @@ const Python = "python"
 // can be reused.
 const DepKey = "dependency-sha"
 
-var Priorities = []interface{}{"buildpack.yml"}
+// Priorities is a list of version-source values that may appear in
+// the BuildpackPlan entries that the buildpack receives. The list is
+// from highest priority to lowest priority and determines the precedence
+// of version-sources.
+var Priorities = []interface{}{
+	"BP_CPYTHON_VERSION",
+	"buildpack.yml",
+}

--- a/detect.go
+++ b/detect.go
@@ -1,6 +1,7 @@
 package cpython
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit"
@@ -35,6 +36,23 @@ func Detect(buildpackYMLParser VersionParser) packit.DetectFunc {
 
 		// TODO(restructure): Remove legacy requirements
 		var requirementsLegacy []packit.BuildPlanRequirement
+
+		if version, ok := os.LookupEnv("BP_CPYTHON_VERSION"); ok {
+			requirements = append(requirements, packit.BuildPlanRequirement{
+				Name: Cpython,
+				Metadata: BuildPlanMetadata{
+					Version:       version,
+					VersionSource: "BP_CPYTHON_VERSION",
+				},
+			})
+			requirementsLegacy = append(requirementsLegacy, packit.BuildPlanRequirement{
+				Name: Python,
+				Metadata: BuildPlanMetadata{
+					Version:       version,
+					VersionSource: "BP_CPYTHON_VERSION",
+				},
+			})
+		}
 
 		version, err := buildpackYMLParser.ParseVersion(filepath.Join(context.WorkingDir, "buildpack.yml"))
 		if err != nil {

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,6 +2,7 @@ package cpython_test
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit"
@@ -82,6 +83,53 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 								Metadata: cpython.BuildPlanMetadata{
 									Version:       "some-version",
 									VersionSource: "buildpack.yml",
+								},
+							},
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("when the BP_CPYTHON_VERSION env var is set", func() {
+		it.Before(func() {
+			os.Setenv("BP_CPYTHON_VERSION", "some-version")
+		})
+
+		it.After(func() {
+			os.Unsetenv("BP_CPYTHON_VERSION")
+		})
+
+		it("returns a plan that provides and requires that version of cpython", func() {
+			result, err := detect(packit.DetectContext{
+				WorkingDir: "/working-dir",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: cpython.Cpython},
+				},
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: cpython.Cpython,
+						Metadata: cpython.BuildPlanMetadata{
+							Version:       "some-version",
+							VersionSource: "BP_CPYTHON_VERSION",
+						},
+					},
+				},
+				Or: []packit.BuildPlan{
+					{
+						Provides: []packit.BuildPlanProvision{
+							{Name: cpython.Python},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: cpython.Python,
+								Metadata: cpython.BuildPlanMetadata{
+									Version:       "some-version",
+									VersionSource: "BP_CPYTHON_VERSION",
 								},
 							},
 						},

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Masterminds/semver v1.5.0
 	github.com/onsi/gomega v1.11.0
 	github.com/paketo-buildpacks/occam v0.1.2
 	github.com/paketo-buildpacks/packit v0.10.0

--- a/init_test.go
+++ b/init_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUnitPython(t *testing.T) {
-	suite := spec.New("python", spec.Report(report.Terminal{}))
+	suite := spec.New("python", spec.Report(report.Terminal{}), spec.Sequential())
 	suite("Build", testBuild)
 	suite("BuildpackYMLParser", testBuildpackYMLParser)
 	suite("Detect", testDetect)

--- a/integration/buildpack_yml_test.go
+++ b/integration/buildpack_yml_test.go
@@ -77,7 +77,7 @@ func testBuildpackYAML(t *testing.T, context spec.G, it spec.S) {
 				"",
 				MatchRegexp(`    Selected CPython version \(using buildpack.yml\): 3\.\d+\.\d+`),
 				"",
-				MatchRegexp(`    WARNING\: Setting the CPython version through buildpack\.yml will be deprecated soon in CPython Buildpack v\d+\.0\.0\.`),
+				MatchRegexp(`    WARNING\: Setting the CPython version through buildpack\.yml is deprecated and will be removed in Paketo CPython Buildpack v\d+\.0\.0\.`),
 				"    Please specify the version through the $BP_CPYTHON_VERSION environment variable instead. See docs for more information.",
 				"",
 				"  Executing build process",

--- a/integration/buildpack_yml_test.go
+++ b/integration/buildpack_yml_test.go
@@ -46,7 +46,7 @@ func testBuildpackYAML(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
 		})
 
-		it("builds with the settings in buildpack.yml", func() {
+		it("builds with the settings in buildpack.yml AND logs a deprecation warning", func() {
 			var err error
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
@@ -76,6 +76,9 @@ func testBuildpackYAML(t *testing.T, context spec.G, it spec.S) {
 				"      <unknown>     -> \"\"",
 				"",
 				MatchRegexp(`    Selected CPython version \(using buildpack.yml\): 3\.\d+\.\d+`),
+				"",
+				MatchRegexp(`    WARNING\: Setting the CPython version through buildpack\.yml will be deprecated soon in CPython Buildpack v\d+\.0\.0\.`),
+				"    Please specify the version through the $BP_CPYTHON_VERSION environment variable instead. See docs for more information.",
 				"",
 				"  Executing build process",
 				MatchRegexp(`    Installing CPython 3\.\d+\.\d+`),

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -80,9 +80,9 @@ func TestIntegration(t *testing.T) {
 
 	SetDefaultEventuallyTimeout(5 * time.Second)
 
-	suite := spec.New("Integration", spec.Report(report.Terminal{}))
-	suite("BuildpackYAML", testBuildpackYAML, spec.Parallel())
-	suite("Default", testDefault, spec.Parallel())
+	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
+	suite("BuildpackYAML", testBuildpackYAML)
+	suite("Default", testDefault)
 	suite("Offline", testOffline)
 	suite("LayerReuse", testLayerReuse)
 	suite.Run(t)

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -192,6 +192,8 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"",
 				MatchRegexp(`    Selected CPython version \(using buildpack.yml\): 3\.\d+\.\d+`),
 				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing CPython 3\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
@@ -228,6 +230,8 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"",
 				MatchRegexp(`    Selected CPython version \(using buildpack.yml\): 3\.\d+\.\d+`),
 				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing CPython 3\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),


### PR DESCRIPTION
Resolves #178 

The buildpack will now:
- warn if `buildpack.yml` is used to configure version
- look for `BP_CPYTHON_VERSION` as the highest-priority version source

Also updated the docs to reflect the new configuration option and added some missing godoc.